### PR TITLE
Fix admin subscriber management

### DIFF
--- a/observatorio/admin.py
+++ b/observatorio/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from .models import Categoria, Informe, ConsultaUsuario
+from .models import Categoria, Informe, ConsultaUsuario, Suscriptor
 
 admin.site.register(Categoria)
 admin.site.register(Informe)
 admin.site.register(ConsultaUsuario)
+admin.site.register(Suscriptor)


### PR DESCRIPTION
## Summary
- include Suscriptor model in Django admin registration
- add newline at end of file

## Testing
- `python -m py_compile observatorio/admin.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f774db8c08323aa76d371e05c6abe