### PR TITLE
Add about view and navbar partial

### DIFF
--- a/observatorio/templates/observatorio/about.html
+++ b/observatorio/templates/observatorio/about.html
@@ -1,0 +1,10 @@
+{% extends 'observatorio/base.html' %}
+
+{% block title %}Acerca de{% endblock %}
+
+{% block content %}
+<div class="container text-center">
+  <h2 class="mb-4">Sobre este proyecto</h2>
+  <p class="lead">Esta página es un ejemplo sencillo desarrollado en Django para practicar la estructura MVT.</p>
+</div>
+{% endblock %}

--- a/observatorio/templates/observatorio/base.html
+++ b/observatorio/templates/observatorio/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Observatorio de Contenidos Digitales</title>
+    <title>{% block title %}Observatorio de Contenidos Digitales{% endblock %}</title>
     <link rel="icon" type="image/png" href="{% static 'images/icono.png' %}" />
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" />
@@ -22,34 +22,13 @@
 
   <body id="page-top">
     <!-- Navigation-->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
-      <div class="container px-4">
-        <a class="navbar-brand d-flex align-items-center" href="{% url 'home' %}">
-          <img src="{% static 'images/icono.png' %}" alt="Logo" height="30" class="me-2">
-          <span>SÍNTESIS ESTRATÉGICA</span>
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-          data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
-          aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-          <ul class="navbar-nav ms-auto">
-            <li class="nav-item"><a class="nav-link" href="{% url 'listar_informes' %}">Ver Informes</a></li>
-            <li class="nav-item"><a class="nav-link" href="{% url 'crear_informe' %}">Cargar Informe</a></li>
-            <li class="nav-item"><a class="nav-link" href="{% url 'buscar_informes' %}">Buscar</a></li>
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'suscribirse' %}">
-                Suscribirse
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+    {% include 'observatorio/navbar.html' %}
 
     <!-- Header de bienvenida -->
     <!-- Header de bienvenida -->
+    {% block header %}
     <header class="text-white" style="
-        background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), 
+        background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)),
                     url('{% static "images/fondo-seccion.png" %}');
         background-size: cover;
         background-position: center;
@@ -60,6 +39,7 @@
         <p class="lead">Estudios, informes y herramientas para entender consumos y hábitos en entornos digitales</p>
       </div>
     </header>
+    {% endblock %}
 
 
 

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -1,0 +1,23 @@
+{% load static %}
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
+  <div class="container px-4">
+    <a class="navbar-brand d-flex align-items-center" href="{% url 'home' %}">
+      <img src="{% static 'images/icono.png' %}" alt="Logo" height="30" class="me-2">
+      <span>SÍNTESIS ESTRATÉGICA</span>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+      data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
+      aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+    <div class="collapse navbar-collapse" id="navbarResponsive">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="{% url 'home' %}">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'about' %}">About</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'listar_informes' %}">Pages</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'crear_informe' %}">Cargar Informe</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'buscar_informes' %}">Buscar</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'suscribirse' %}">Suscribirse</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'admin:login' %}">Login</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.home, name='home'),
+    path('about/', views.about, name='about'),
     path('crear/', views.crear_informe, name='crear_informe'),
     path('informes/', views.listar_informes, name='listar_informes'),
     path('buscar/', views.buscar_informes, name='buscar_informes'),

--- a/observatorio/views.py
+++ b/observatorio/views.py
@@ -8,6 +8,11 @@ from django.db.models import Q
 def home(request):
     return render(request, 'observatorio/home.html')
 
+
+def about(request):
+    """Muestra información general del sitio."""
+    return render(request, 'observatorio/about.html')
+
 def crear_informe(request):
     if request.method == 'POST':
         form = InformeForm(request.POST)


### PR DESCRIPTION
## Summary
- improve base template to support reusable blocks
- add new reusable navigation bar template
- create simple about page and view
- wire new page in urls

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f8b1d9d54832383faf75ee8d1f530