### PR TITLE
Implement basic user login

### DIFF
--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -1,5 +1,7 @@
 from django import forms
-from .models import Categoria, Informe, ConsultaUsuario, Suscriptor
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+from .models import Categoria, Informe, ConsultaUsuario, Suscriptor, Perfil
 
 class CategoriaForm(forms.ModelForm):
     class Meta:
@@ -40,5 +42,22 @@ class ConsultaUsuarioForm(forms.ModelForm):
     class Meta:
         model = ConsultaUsuario
         fields = '__all__'
+
+
+class RegistroUsuarioForm(UserCreationForm):
+    first_name = forms.CharField(label='Nombre', max_length=100, widget=forms.TextInput(attrs={'class': 'form-control'}))
+    last_name = forms.CharField(label='Apellido', max_length=100, widget=forms.TextInput(attrs={'class': 'form-control'}))
+    email = forms.EmailField(label='Email', widget=forms.EmailInput(attrs={'class': 'form-control'}))
+    dni = forms.CharField(label='DNI', max_length=20, widget=forms.TextInput(attrs={'class': 'form-control'}))
+
+    class Meta:
+        model = User
+        fields = ['username', 'first_name', 'last_name', 'dni', 'email', 'password1', 'password2']
+
+    def save(self, commit=True):
+        user = super().save(commit)
+        dni = self.cleaned_data['dni']
+        Perfil.objects.create(user=user, dni=dni)
+        return user
 
 

--- a/observatorio/models.py
+++ b/observatorio/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 class Categoria(models.Model):
     nombre = models.CharField(max_length=100)
@@ -33,4 +34,12 @@ class Suscriptor(models.Model):
 
     def __str__(self):
         return f"{self.nombre} {self.apellido} ({self.email})"
+
+
+class Perfil(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    dni = models.CharField(max_length=20)
+
+    def __str__(self):
+        return f"Perfil de {self.user.username}"
 

--- a/observatorio/templates/observatorio/login.html
+++ b/observatorio/templates/observatorio/login.html
@@ -1,0 +1,13 @@
+{% extends 'observatorio/base.html' %}
+{% block content %}
+  <h2>Iniciar sesión</h2>
+  {% if request.GET.next %}
+    <div class="alert alert-warning">Para acceder a los informes debe loguearse.</div>
+  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Ingresar</button>
+  </form>
+  <p class="mt-3">¿No tenés cuenta? <a href="{% url 'registro_usuario' %}">Registrate</a></p>
+{% endblock %}

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -16,7 +16,11 @@
         <li class="nav-item"><a class="nav-link" href="{% url 'crear_informe' %}">Cargar Informe</a></li>
         <li class="nav-item"><a class="nav-link" href="{% url 'buscar_informes' %}">Buscar</a></li>
         <li class="nav-item"><a class="nav-link" href="{% url 'suscribirse' %}">Suscribirse</a></li>
-        <li class="nav-item"><a class="nav-link" href="{% url 'admin:login' %}">Login</a></li>
+        {% if user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'logout' %}">Logout</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
+        {% endif %}
       </ul>
     </div>
   </div>

--- a/observatorio/templates/observatorio/registro.html
+++ b/observatorio/templates/observatorio/registro.html
@@ -1,0 +1,9 @@
+{% extends 'observatorio/base.html' %}
+{% block content %}
+  <h2>Registro de usuario</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-success">Registrarme</button>
+  </form>
+{% endblock %}

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -11,4 +11,7 @@ urlpatterns = [
     path('informe/<int:informe_id>/', views.detalle_informe, name='detalle_informe'),
     path('informe/<int:informe_id>/editar/', views.editar_informe, name='editar_informe'),
     path('informe/<int:informe_id>/eliminar/', views.eliminar_informe, name='eliminar_informe'),
+    path('login/', views.UsuarioLoginView.as_view(), name='login'),
+    path('logout/', views.UsuarioLogoutView.as_view(), name='logout'),
+    path('registro/', views.registro_usuario, name='registro_usuario'),
 ]


### PR DESCRIPTION
## Summary
- add `Perfil` model for DNI
- add `RegistroUsuarioForm` form and custom login/registro templates
- add login/logout/registro views and URLs
- protect informe views with login_required
- update navbar login logic

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f8dbcda8c8323bf8e63a1758249e9