### PR TITLE
Mejora pantalla de registro y mensajes en español

### DIFF
--- a/TuPrimeraPaginaBonacci/settings.py
+++ b/TuPrimeraPaginaBonacci/settings.py
@@ -105,7 +105,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'es'
 
 TIME_ZONE = 'UTC'
 

--- a/observatorio/templates/observatorio/base.html
+++ b/observatorio/templates/observatorio/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/observatorio/templates/observatorio/iniciar_sesion.html
+++ b/observatorio/templates/observatorio/iniciar_sesion.html
@@ -1,0 +1,21 @@
+{% extends 'observatorio/base.html' %}
+{% block content %}
+<div class="row">
+  <div class="col-md-6 mb-4">
+    <h2>Iniciar sesión</h2>
+    <form method="post">
+      {% csrf_token %}
+      {{ login_form.as_p }}
+      <button type="submit" name="login_submit" class="btn btn-primary">Ingresar</button>
+    </form>
+  </div>
+  <div class="col-md-6">
+    <h2>Registrarse</h2>
+    <form method="post">
+      {% csrf_token %}
+      {{ reg_form.as_p }}
+      <button type="submit" name="registro_submit" class="btn btn-success">Registrarme</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -19,8 +19,7 @@
         {% if user.is_authenticated %}
           <li class="nav-item"><a class="nav-link" href="{% url 'logout_usuario' %}">Cerrar sesión</a></li>
         {% else %}
-          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Logearse</a></li>
-          <li class="nav-item"><a class="nav-link" href="{% url 'registro_usuario' %}">Registrarse</a></li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'registro_usuario' %}">Iniciar Sesión</a></li>
         {% endif %}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- unificar registro y login en una sola vista
- actualizar el idioma del sitio a español
- ajustar navegación para que diga *Iniciar Sesión*

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f934b13fc8323b7b86c3f8b99ff7a